### PR TITLE
Remove gaps around GTK windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .assets
+.vscode
+__debug_bin


### PR DESCRIPTION
Thank you for cortile.  I've been using it for a few days now and I like it.

As mentioned in Issue #3, the EWMH protocol may not help directly but...
GTK apps will add a `_GTK_FRAME_EXTENTS` property to the window with the sizes of it's margins so it's possible to use it to account for the gaps around GTK "CSD" windows.

I'm not particularly familiar with Go or X11 so the approach and code may not be optimal but it works when tiling GTK apps and also when restoring them to their original, stored, positions.

As for my changes:
* The flag (`Client.Info.IsGtkCSD`) has been added simply to avoid having to keep querying X properties.
* Since `MoveResize()` was called when tiling and restoring, I had to add an extra parameter to control whether the adjustment should be made or not.
* The .gitignore change is just to keep vscode and debug artifacts out.
