### PR TITLE
fix: report config file errors on startup

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -84,7 +84,12 @@ func readConfig(configFilePath string) {
 	fmt.Printf("FILES: \n  log: %s\n  lock: %s\n  cache: %s\n  config: %s\n\n", Args.Log, Args.Lock, Args.Cache, configFilePath)
 
 	// Decode config file into struct
-	toml.DecodeFile(configFilePath, &Config)
+	_, err := toml.DecodeFile(configFilePath, &Config)
+	if err != nil {
+		log.
+			WithFields(log.Fields{"File": configFilePath}).
+			Fatal("Error reading config file: ", err)
+	}
 
 	// Print shortcut infos
 	keys, _ := json.MarshalIndent(Config.Keys, "", "  ")


### PR DESCRIPTION
Hi  - I stumbled upon the problem that if you're stupid enough to mis-edit the config file, Cortile will continue regardless - crashing further down the line (with a divide by zero error in my particular case).

The decode function will report errors (with line numbers) if the config file is malformed in some way.
This change simply surfaces that.