### PR TITLE
Allow caching to be controlled in the config file (and in a more fine-grained way)

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -44,6 +44,15 @@ type Configuration struct {
 	Systray           map[string]string `toml:"systray"`             // Event bindings for systray icon
 }
 
+/*
+Partially for backward compatibility, partially to stop the config file getting huge,
+for the options which are not commonly needed/wanted, set their default values.
+*/
+func SetConfigDefaults() {
+	Config.CacheWindows = true
+	Config.CacheWorkspaces = true
+}
+
 func InitConfig() {
 
 	// Create config folder if not exists
@@ -86,6 +95,8 @@ func readConfig(configFilePath string, initial bool) {
 		fmt.Printf(": \n  name: %s\n  target: %s\n  version: v%s-%s\n  date: %s\n  flags: %s\n\n", Build.Name, Build.Target, Build.Version, Build.Commit, Build.Date, Build.Flags)
 		fmt.Printf("FILES: \n  log: %s\n  lock: %s\n  cache: %s\n  config: %s\n\n", Args.Log, Args.Lock, Args.Cache, configFilePath)
 	}
+
+	SetConfigDefaults()
 
 	// Decode config file into struct
 	_, err := toml.DecodeFile(configFilePath, &Config)

--- a/common/config.go
+++ b/common/config.go
@@ -19,6 +19,8 @@ var (
 )
 
 type Configuration struct {
+	CacheWorkspaces   bool              `toml:"cache_workspaces"`    // Cache workspace properties (Tiling enablement, Current layout, proportions)
+	CacheWindows      bool              `toml:"cache_windows"`       // Cache window properties ( Positions, Dimensions)
 	TilingEnabled     bool              `toml:"tiling_enabled"`      // Tile windows on startup
 	TilingLayout      string            `toml:"tiling_layout"`       // Initial tiling layout
 	TilingCycle       []string          `toml:"tiling_cycle"`        // Cycle layout order

--- a/config.toml
+++ b/config.toml
@@ -9,12 +9,6 @@
 # Initial tiling activation, will be cached afterwards (true | false).
 tiling_enabled = true
 
-# Cache Workspace Tiling enablement, current layouts, etc
-cache_workspaces = true
-
-# Do not cache window positions
-cache_windows = false
-
 # Initial tiling layout, will be cached afterwards ("vertical-left" | "vertical-right" | "horizontal-top" | "horizontal-bottom" | "maximized" | "fullscreen").
 tiling_layout = "vertical-right"
 

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,12 @@
 # Initial tiling activation, will be cached afterwards (true | false).
 tiling_enabled = true
 
+# Cache Workspace Tiling enablement, current layouts, etc
+cache_workspaces = true
+
+# Do not cache window positions
+cache_windows = false
+
 # Initial tiling layout, will be cached afterwards ("vertical-left" | "vertical-right" | "horizontal-top" | "horizontal-bottom" | "maximized" | "fullscreen").
 tiling_layout = "vertical-right"
 

--- a/desktop/workspace.go
+++ b/desktop/workspace.go
@@ -235,7 +235,7 @@ func (ws *Workspace) Restore(flag uint8) {
 }
 
 func (ws *Workspace) Write() {
-	if common.CacheDisabled() {
+	if common.CacheDisabled() || !common.Config.CacheWorkspaces {
 		return
 	}
 
@@ -261,7 +261,7 @@ func (ws *Workspace) Write() {
 }
 
 func (ws *Workspace) Read() *Workspace {
-	if common.CacheDisabled() {
+	if common.CacheDisabled() || !common.Config.CacheWorkspaces {
 		return ws
 	}
 

--- a/store/client.go
+++ b/store/client.go
@@ -342,7 +342,7 @@ func (c *Client) Update() {
 }
 
 func (c *Client) Write() {
-	if common.CacheDisabled() {
+	if common.CacheDisabled() || !common.Config.CacheWindows {
 		return
 	}
 
@@ -368,7 +368,7 @@ func (c *Client) Write() {
 }
 
 func (c *Client) Read() *Client {
-	if common.CacheDisabled() {
+	if common.CacheDisabled()  || !common.Config.CacheWindows {
 		return c
 	}
 


### PR DESCRIPTION
Hi there @leukipp - Happy New Year! - I'd appreciate it if you'd accept all, or at least part of, this PR!

When starting up from a saved Desktop session:
Caching window positions has been unreliable for things like browser windows (e.g Firefox).
They will all have the same WM_CLASS and window title on start-up, updating multiple times thereafter, so will not match cortile's cached values when it sees them.
This means windows get placed on the wrong workspace, or worse, assumed to be on a workspace they are not so layouts end up with "holes" in them.

Disabling the cache entirely is an option but having the workspace tiling settings, proportions, etc remembered is a really nice feature that I don't want to have to lose.

This PR adds `cache_workspaces` and `cache_windows` to the config to individually control what gets cached, but still allow the command-line flag to override the settings and disable the cache entirely.

There's 2 commits in it:
1. 72877b1 - Makes the 2 config values available in the config file.
2. 6a4df90 - Make them optional, with defaults set into the config struct before decoding, to allow them to be left out.